### PR TITLE
Motwicemo

### DIFF
--- a/redfish-server/sidecar-redfish/app.py
+++ b/redfish-server/sidecar-redfish/app.py
@@ -93,9 +93,18 @@ api = Api(
 )
 
 
-@app.route("/redfish", methods=["GET"])
+@app.route("/redfish", methods=["GET"], strict_slashes=False)
 def redfish_root():
-    return jsonify({"v1": "/redfish/v1/"})
+    root = {
+        "@odata.id": "/redfish",
+        "@odata.type": "#RedfishVersionCollection.RedfishVersionCollection",
+        "Name": "Redfish Service Versions",
+        "Members@odata.count": 1,
+        "Members": [
+            { "@odata.id": "/redfish/v1" }
+        ]
+    }
+    return root, 200
 
 
 @app.route("/debug", methods=["GET"])

--- a/redfish-server/sidecar-redfish/metadata.xml
+++ b/redfish-server/sidecar-redfish/metadata.xml
@@ -40,6 +40,15 @@
       <edmx:Include Namespace="TelemetryService.v1_3_4" Alias="TelemetryService"/> 
     </edmx:Reference> 
 
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/MetricReport_v1.xml">
+      <edmx:Include Namespace="MetricReport"/>  
+      <edmx:Include Namespace="MetricReport.v1_5_2" Alias="MetricReport"/> 
+    </edmx:Reference> 
+    
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/MetricReportCollection_v1.xml">
+      <edmx:Include Namespace="MetricReportCollection"/>
+    </edmx:Reference>
+
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ThermalEquipment_v1.xml">
       <edmx:Include Namespace="ThermalEquipment"/>  
       <edmx:Include Namespace="ThermalEquipment.v1_1_2" Alias="ThermalEquipment"/> 
@@ -323,7 +332,12 @@
     <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/FilterCollection_v1.xml">
       <edmx:Include Namespace="FilterCollection"/>
     </edmx:Reference>    
-  	
+
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/MetricReport_v1.xml">
+      <edmx:Include Namespace="MetricReport"/>
+      <edmx:Include Namespace="MetricReport.v1_5_2"/>
+    </edmx:Reference>    	
+    
   <!-- service -->
   <edmx:DataServices>
     <Schema Namespace="RedfishService" xmlns="http://docs.oasis-open.org/odata/ns/edm">

--- a/redfish-server/sidecar-redfish/mylib/models/rf_ethernetinterfaces_model.py
+++ b/redfish-server/sidecar-redfish/mylib/models/rf_ethernetinterfaces_model.py
@@ -1,0 +1,86 @@
+from typing import Optional, List, Dict, Any
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field, 
+    computed_field,
+    model_validator,
+    #validator, # deprecated
+    field_validator,
+)
+from mylib.models.rf_base_model import RfResourceBaseModel
+from mylib.utils.network_info import get_network_protocol_status
+from mylib.models.rf_snmp_model import rf_SNMP
+from mylib.models.rf_base_model import RfResourceCollectionBaseModel
+from mylib.models.rf_status_model import RfStatusModel
+
+class RfEthernetInterfacesModel(RfResourceCollectionBaseModel):
+    Odata_context: Optional[str] = Field(default=None, alias="@odata.context")
+    
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)    
+        self.odata_id = "/redfish/v1/Managers/CDU/EthernetInterfaces"
+        self.odata_type = "#EthernetInterfaceCollection.EthernetInterfaceCollection"
+        self.Odata_context = "/redfish/v1/$metadata#EthernetInterfaceCollection.EthernetInterfaceCollection"
+        
+        self.Name = "Ethernet Network Interface Collection"
+        self.Description = "Network Interface Collection for the CDU Management Controller"
+        
+        
+        
+        
+class RfEthernetInterfacesIdModel(RfResourceBaseModel):
+    # ipv4
+    class _ipv4_addresses(BaseModel):
+        Address: Optional[str] = Field(default=None)
+        SubnetMask: Optional[str] = Field(default=None)
+        AddressOrigin: Optional[str] = Field(default=None)
+        Gateway: Optional[str] = Field(default=None)
+        Oem: Optional[Any] = Field(default=None)
+    
+    # ipv6
+    class _ipv6_addresses(BaseModel):
+        Address: Optional[str] = Field(default=None)
+        PrefixLength: Optional[str] = Field(default=None)
+        AddressOrigin: Optional[str] = Field(default=None)
+        AddressState: Optional[str] = Field(default=None)
+        Oem: Optional[Any] = Field(default=None)
+    
+    # models
+    Odata_context: Optional[str] = Field(default=None, alias="@odata.context")
+    Description: Optional[str] = Field(default=None)
+    Status: Optional[RfStatusModel] = Field(default=None)
+    LinkStatus: Optional[str] = Field(default=None)
+    InterfaceEnabled: Optional[bool] = Field(default=None)
+    PermanentMACAddress: Optional[str] = Field(default=None)
+    MACAddress: Optional[str] = Field(default=None)
+    SpeedMbps: Optional[int] = Field(default=None)
+    AutoNeg: Optional[bool] = Field(default=None)
+    FullDuplex: Optional[bool] = Field(default=None)
+    MTUSize: Optional[int] = Field(default=None)
+    
+    Redfish_WriteableProperties: Optional[List[str]] = Field(default=None, alias="@Redfish.WriteableProperties")
+    
+    HostName: Optional[str] = Field(default=None)
+    FQDN: Optional[str] = Field(default=None)
+    
+    IPv4Addresses: Optional[_ipv4_addresses] = Field(default=None)
+    MaxIPv6StaticAddresses: Optional[int] = Field(default=None)
+    # IPv6AddressPolicyTable: Optional[_ipv6addresspolicytable] = Field(default=None)
+    # IPv6StaticAddresses: Optional[List[_ipv6_addresses]] = Field(default=None)
+    # IPv6DefaultGateway: Optional[_ipv6_addresses] = Field(default=None)
+    IPv6Addresses: Optional[List[_ipv6_addresses]] = Field(default=None)
+    NameServers: Optional[List[str]] = Field(default=None)
+    
+    Oem: Optional[Any] = Field(default=None)
+    
+    def __init__(self, ethernet_interfaces_id: str, **kwargs):
+        super().__init__(**kwargs)
+        self.odata_id = f"/redfish/v1/Managers/CDU/EthernetInterfaces/{ethernet_interfaces_id}"
+        self.odata_type = "#EthernetInterface.v1_12_4.EthernetInterface"
+        self.Odata_context = "/redfish/v1/$metadata#EthernetInterface.v1_12_4.EthernetInterface"
+        
+        self.Id = ethernet_interfaces_id
+        self.Name = f"Manager Ethernet Interface {ethernet_interfaces_id}"
+        self.Description = "Network Interface of the CDU Management Controller"

--- a/redfish-server/sidecar-redfish/mylib/models/rf_metric_report_definition_model.py
+++ b/redfish-server/sidecar-redfish/mylib/models/rf_metric_report_definition_model.py
@@ -9,6 +9,56 @@ from pydantic import (
     field_validator,
 )
 from mylib.models.rf_base_model import RfResourceBaseModel, RfResourceCollectionBaseModel
+from mylib.models.rf_metric_report_model import RfMetricReportModel
+from mylib.models.rf_status_model import RfStatusModel
+
+class RfActions(BaseModel):
+    # Oem: Optional[RfOemActions] = Field(default=None) # why fail?
+    Oem: Optional[Dict[str, Any]] = Field(default=None)
+
+class RfCalculationAlgorithmEnum(str, Enum):
+    Average = "Average"
+    Maximum = "Maximum"
+    Minimum = "Minimum"
+    Summation = "Summation"
+
+class RfCollectionTimeScope(str, Enum):
+    Point = "Point"
+    Interval = "Interval"
+    StartupInterval = "StartupInterval"
+
+class RfLink(BaseModel):
+    Oem: Optional[Dict[str, Any]] = Field(default=None)
+    Triggers: Optional[Dict[str, Any]] = Field(default=None) 
+    Triggers_odata_count: Optional[int] = Field(default=None, alias="@odata.count")
+
+class RfMetric(BaseModel):
+    CollectionDuration: Optional[str] = Field(default=None)
+    CollectionFunction: Optional[RfCalculationAlgorithmEnum] = Field(default=None)
+    CollectionTimeScope: Optional[RfCollectionTimeScope] = Field(default=None)
+    MetricId: Optional[str] = Field(default=None)
+    MetricProperty: Optional[str] = Field(default=None)
+    Oem: Optional[Dict[str, Any]] = Field(default=None)
+
+class RfMetricReportDefinitionType(str, Enum):
+    Periodic = "Periodic"
+    Onchange = "OnChange"
+    OnRequest = "OnRequest"
+
+class RfReportActions(str, Enum):
+    LogToMetricReportsCollection = "LogToMetricReportsCollection"
+    RedfishEvent = "RedfishEvent"
+
+class RfReportUpdates(str, Enum):
+    Overwrite = "Overwrite"
+    AppendWrapsWhenFull = "AppendWrapsWhenFull"
+    AppendStopsWhenFull = "AppendStopsWhenFull"
+    NewReport = "NewReport"
+
+class RfWildcard(BaseModel):
+    Keys: Optional[List[Optional[str]]] = Field(default=None)
+    Name: Optional[str] = Field(default=None)
+    Values: Optional[List[Optional[str]]] = Field(default=None)
 
 
 
@@ -27,11 +77,52 @@ class RfMetricReportDefinitionModel(RfResourceBaseModel):
             "Name"
         ]
     """
-    ...
+
+    odata_context: Optional[str] = Field(default=None, alias="@odata.context")
+    odata_etag: Optional[str] = Field(default=None, alias="@odata.etag") 
+    # odata_id: Optional[str] = Field(default=None, alias="@odata.id")
+    # odata_type: Optional[str] = Field(default=None, alias="@odata.type")
+    Actions: Optional[RfActions] = Field(default=None)
+    AppendLimit: Optional[int] = Field(default=None)
+    Description: Optional[str] = Field(default=None)
+    # Id: Optional[str] = Field(default=None)
+    Links: Optional[RfLink] = Field(default=None)
+    MetricProperties: Optional[List[Optional[str]]] = Field(default=None)
+    MetricReport: Optional[RfMetricReportModel] = Field(default=None)
+    MetricReportDefinitionEnabled: Optional[bool] = Field(default=None)
+    MetricReportDefinitionType: Optional[RfMetricReportDefinitionType] = Field(default=None)
+    MetricReportHeartbeatInterval: Optional[str] = Field(default=None)
+    Metrics: Optional[List[RfMetric]] = Field(default=None)
+    # Name: Optional[str] = Field(default=None)
+    Oem: Optional[dict[str, Any]] = Field(default=None)
+    ReportActions: Optional[RfReportActions] = Field(default=None)
+    ReportTimespan: Optional[str] = Field(default=None)
+    ReportUpdates: Optional[RfReportUpdates] = Field(default=None)
+    Schedule: Optional[Dict[str, Any]] = Field(default=None)
+    Status: Optional[RfStatusModel] = Field(default=None)
+    SuppressRepeatedMetricValue: Optional[bool] = Field(default=None)
+    Wildcards: Optional[List[Optional[RfWildcard]]] = Field(default=None)
 
 
 class RfMetricReportDefinitionCollectionModel(RfResourceCollectionBaseModel):
     """
     @see https://redfish.dmtf.org/schemas/v1/MetricReportDefinitionCollection.json
+    @note properties 10 items
+    @note "required": [
+            "Members",
+            "Members@odata.count",
+            "@odata.id",
+            "@odata.type",
+            "Name"
+        ],
     """
-    pass
+    # odata_id: Optional[str] = Field(default=None, alias="@odata.id")
+    # odata_type: Optional[str] = Field(default=None, alias="@odata.type")
+    # Members: List[Dict[str, Any]] = Field(default=[], description="")
+    # Members_odata_count: int = Field(default=0, description="", alias="Members@odata.count")
+    # Name: str = Field(default="", description="")
+    odata_context: Optional[str] = Field(default=None, alias="@odata.context")
+    odata_etag: Optional[str] = Field(default=None, alias="@odata.etag")
+    Description: Optional[str] = Field(default=None)
+    Members_odata_nextLink: Optional[str] = Field(default=None, description="", alias="@odata.nextLink")
+    Oem: Optional[Dict[str, Any]] = Field(default=None, description="")

--- a/redfish-server/sidecar-redfish/mylib/models/rf_metric_report_model.py
+++ b/redfish-server/sidecar-redfish/mylib/models/rf_metric_report_model.py
@@ -1,0 +1,51 @@
+from enum import Enum
+from typing import Optional, List, Dict, Any
+from pydantic import (
+    BaseModel,
+    Field, 
+    computed_field,
+    model_validator,
+    #validator, # deprecated
+    field_validator,
+)
+from mylib.models.rf_base_model import RfResourceBaseModel, RfResourceCollectionBaseModel
+
+class RfActions(BaseModel):
+    # Oem: Optional[RfOemActions] = Field(default=None) # why fail?
+    Oem: Optional[Dict[str, Any]] = Field(default=None)
+
+class RfMetricValue(BaseModel):
+    MetricDefinition: Optional[Dict[str, Any]] = Field(default=None)  
+    MetricId: Optional[str] = Field(default=None)
+    MetricProperty: Optional[str] = Field(default=None)
+    MetricValue: Optional[str] = Field(default=None)
+    Oem: Optional[Dict[str, Any]] = Field(default=None)
+    Timestamp: Optional[str] = Field(default=None)
+
+class RfMetricReportModel(RfResourceBaseModel):
+    """
+    @see https://redfish.dmtf.org/schemas/v1/MetricReport.json
+    @see https://redfish.dmtf.org/schemas/v1/MetricReport.v1_5_2.json#/definitions/MetricReport
+    @note properties 14 items
+    @note 
+        required: [
+            "@odata.id",
+            "@odata.type",
+            "Id",
+            "Name"
+        ]
+    """
+    odata_context: Optional[str] = Field(default=None, alias="@odata.context")
+    odata_etag: Optional[str] = Field(default=None, alias="@odata.etag")
+    # odata_id: Optional[str] = Field(default=None, alias="@odata.id")
+    # odata_type: Optional[str] = Field(default=None, alias="@odata.type")
+    Actions: Optional[RfActions] = Field(default=None)
+    Context: Optional[str] = Field(default=None)
+    Description: Optional[str] = Field(default=None)
+    # Id: Optional[str] = Field(default=None)
+    MetricReportDefinition: Optional[Dict[str, Any]] = Field(default=None) # This could be a reference to another resource
+    MetricValues: Optional[RfMetricValue] = Field(default=None)
+    # Name: Optional[str] = Field(default=None)
+    Oem: Optional[Dict[str, Any]] = Field(default=None)
+    ReportSequence: Optional[str] = Field(default=None)
+    Timestamp: Optional[str] = Field(default=None, description="The timestamp of the report in ISO 8601 format.")

--- a/redfish-server/sidecar-redfish/mylib/models/rf_networkprotocol_model.py
+++ b/redfish-server/sidecar-redfish/mylib/models/rf_networkprotocol_model.py
@@ -101,7 +101,7 @@ class RfNetworkProtocolModel(RfResourceBaseModel):
         )
         self.SSH = _rf_SSH(
             ProtocolEnabled = st["SSHEnabled"],
-            Port = st["HTTPPort"]
+            Port = st["SSHPort"]
         )
         self.SNMP = rf_SNMP(
             ProtocolEnabled = st["SNMPEnabled"],

--- a/redfish-server/sidecar-redfish/mylib/models/rf_pump_model.py
+++ b/redfish-server/sidecar-redfish/mylib/models/rf_pump_model.py
@@ -89,12 +89,16 @@ class RfPumpModel(RfResourceBaseModel):
         self.Id = pump_id
         self.PumpType = RfPumpType.Liquid
         self.Name = f"Pump {pump_id}"
-        raw_actions = {
-            "#Pump.SetMode": {
-                "target": f"/redfish/v1/ThermalEquipment/CDUs/{cdu_id}/Pumps/{pump_id}/Actions/Pump.SetMode"
-            }
-        }   
-        self.Actions = RfActions(**raw_actions)
+        m = RfActions()
+        m.PumpSetMode = {
+            "target": f"/redfish/v1/ThermalEquipment/CDUs/{cdu_id}/Pumps/{pump_id}/Actions/Pump.SetMode",
+            "Mode@Redfish.AllowableValues": [
+                "Enabled",
+                "Disabled"
+            ]
+        }
+  
+        self.Actions = m
         self.Location = RfLocationModel(**hardware_info["Pumps"][pump_id]["Location"])
         self.Oem= {
             "supermicro": {

--- a/redfish-server/sidecar-redfish/mylib/routers/Chassis_router.py
+++ b/redfish-server/sidecar-redfish/mylib/routers/Chassis_router.py
@@ -9,7 +9,7 @@ import requests
 import os
 from typing import Dict
 from mylib.common.my_resource import MyResource
-from mylib.utils.system_info import get_system_uuid, list_nics_fullinfo
+from mylib.utils.system_info import get_system_uuid
 
 
 Chassis_ns = Namespace('', description='Chassis Collection')

--- a/redfish-server/sidecar-redfish/mylib/routers/ThermalEquipment_router.py
+++ b/redfish-server/sidecar-redfish/mylib/routers/ThermalEquipment_router.py
@@ -755,8 +755,8 @@ class PrimaryCoolantConnectors1(Resource):
         PrimaryCoolantConnectors_data_1["Oem"]["supermicro"]["PumpSwapTime"]["SetPoint"]["Value"] = pump_swap_time
         
         controlmode = GetControlMode()
-        if controlmode == "Automatic":
-            controlmode = "Manual"
+        # if controlmode == "Automatic":
+        #     controlmode = "Manual"
         PrimaryCoolantConnectors_data_1["SupplyTemperatureControlCelsius"]["ControlMode"] = controlmode
         PrimaryCoolantConnectors_data_1["DeltaPressureControlkPa"]["ControlMode"] = controlmode
         return PrimaryCoolantConnectors_data_1
@@ -1027,7 +1027,7 @@ class LeakDetectionLeakDetectors1(MyBaseThermalEquipment):
         rep = RfThermalEquipmentService().fetch_CDUs_LeakDetection_LeakDetectors_id(cdu_id, leak_detector_id)
         return rep
 
-CoolingUnit_patch = ThermalEquipment_ns.model('CoolingUnitPatch', {
+Mode_common = ThermalEquipment_ns.model('CoolingUnitPatch', {
     'Mode': fields.String(
         required=True,
         description='Automatic Switch',
@@ -1040,12 +1040,21 @@ CoolingUnit_patch = ThermalEquipment_ns.model('CoolingUnitPatch', {
 @ThermalEquipment_ns.route("/ThermalEquipment/CDUs/<string:cdu_id>/Actions/CoolingUnit.SetMode")
 class CoolingUnitSetMode(Resource):
     # # @requires_auth
-    @ThermalEquipment_ns.expect(CoolingUnit_patch, validate=True)
+    @ThermalEquipment_ns.expect(Mode_common, validate=True)
     def post(self, cdu_id):
         data = request.get_json(force=True)
         return RfThermalEquipmentService().fetch_CDUs_SetMode(cdu_id, data)
 
 
+
+
+@ThermalEquipment_ns.route("/ThermalEquipment/CDUs/<string:cdu_id>/Pumps/<string:pump_id>/Actions/Pump.SetMode")
+class PumpSetMode(Resource):
+    # # @requires_auth
+    @ThermalEquipment_ns.expect(Mode_common, validate=True)
+    def post(self, cdu_id, pump_id):
+        data = request.get_json(force=True)
+        return RfThermalEquipmentService().fetch_CDUs_Pumps_SetMode(cdu_id, pump_id, data)
 
 # 0513新增 /redfish/v1/ThermalEquipment/CDUs/{CoolingUnitId}/Oem
 # @ThermalEquipment_ns.route('/ThermalEquipment/CDUs/<string:id>/Oem')

--- a/redfish-server/sidecar-redfish/mylib/routers/mangers_router.py
+++ b/redfish-server/sidecar-redfish/mylib/routers/mangers_router.py
@@ -5,7 +5,7 @@ from mylib.utils.load_api import CDU_BASE
 from mylib.services.rf_managers_service import RfManagersService
 from mylib.models.rf_resource_model import RfResetType
 from mylib.models.rf_manager_model import RfResetToDefaultsType
-from mylib.utils.system_info import get_system_uuid, list_nics_fullinfo
+from mylib.utils.system_info import get_system_uuid
 from mylib.services.rf_log_service import RfLogService
 
 managers_ns = Namespace('', description='Chassis Collection')
@@ -560,21 +560,22 @@ class ManagersCDUNetworkProtocolHTTPSCertificates(Resource):
 #====================================================== 
 # EthernetInterfaces
 #====================================================== 
-@managers_ns.route("/Managers/CDU/EthernetInterfaces")
+@managers_ns.route("/Managers/CDU/EthernetInterfaces") # get
 class ManagersCDUEthernetInterfaces(Resource):
     # # @requires_auth
     @managers_ns.doc("managers_cdu_ethernet_interfaces")
     def get(self):
-        list_nics_fullinfo()
+        # return RfManagersService().get_ethernetinterfaces()
         return ethernet_interfaces_data
     
-@managers_ns.route("/Managers/CDU/EthernetInterfaces/<string:ethernet_interfaces_id>")
+@managers_ns.route("/Managers/CDU/EthernetInterfaces/<string:ethernet_interfaces_id>") # get patch
 class ManagersCDUEthernetInterfacesMain(Resource):
     # # @requires_auth
     @managers_ns.doc("managers_cdu_ethernet_interfaces")
     def get(self, ethernet_interfaces_id):
         ethernet_data = load_raw_from_api(f"{CDU_BASE}/api/v1/cdu/components/network")[ethernet_interfaces_id]
-        print(ethernet_data)
+        # print(ethernet_data)
+        # return RfManagersService().get_ethernetinterfaces_id(ethernet_interfaces_id)
         ethernet_interfaces_main_data ={
             "@odata.id": f"/redfish/v1/Managers/CDU/EthernetInterfaces/{ethernet_interfaces_id}",
             "@odata.type": "#EthernetInterface.v1_12_4.EthernetInterface",
@@ -674,6 +675,27 @@ class ManagersCDUEthernetInterfacesMain(Resource):
             "Oem": {},
         }
         return ethernet_interfaces_main_data    
+        
+        
+        # 可patch的欄位
+        # MACAddress 當前生效的 MAC 位址，可用於作業系統層面識別。
+        # SpeedMbps(AutoNeg=false 才能寫) 	目前連線速率（Mbit/s）
+        # AutoNeg 是否啟用速率／雙工自動協商
+        # FullDuplex	是否啟用全雙工模式。
+        # MTUSize	最大傳輸單元（Bytes），影響封包最大長度。
+        # HostName	DNS 主機名稱（不含網域部分）。
+        # FQDN	完整網域名稱，包含主機＋網域。
+        # NameServers	正在使用中的 DNS 伺服器清單。
+        # StaticNameServers	靜態定義的 DNS 伺服器清單，可與 DHCP 提供項目併用或替代。
+        # IPv4StaticAddresses	靜態 IPv4 位址清單，可新增/刪除/修改。
+        # IPv6StaticAddresses	靜態 IPv6 位址清單，可新增/刪除/修改。
+        # IPv6StaticDefaultGateways	靜態 IPv6 預設閘道清單，可新增/刪除/修改。
+        # DHCPv4	DHCP v4 設定整組（DHCPEnabled、UseDNSServers、UseDomainName、UseGateway、UseNTPServers、UseStaticRoutes）
+        # DHCPv6	DHCP v6 設定整組（OperatingMode、UseDNSServers、UseDomainName、UseNTPServers、UseRapidCommit）
+        # StatelessAddressAutoConfig	SLAAC IPv4/IPv6 自動組態開關（IPv4AutoConfigEnabled、IPv6AutoConfigEnabled）。
+        # VLAN	單一 VLAN 設定：VLANEnable、VLANId、VLANPriority、Tagged。
+        # RelatedInterfaces	團隊介面連結，用於設定 Bonding/Team 組態。
+        # TeamMode	團隊模式（如 None、ActiveBackup、IEEE802_3ad…）。
     
 #=========================================0514新增==================================================  
 # LogServices_data = {

--- a/redfish-server/sidecar-redfish/mylib/routers/root_router.py
+++ b/redfish-server/sidecar-redfish/mylib/routers/root_router.py
@@ -8,7 +8,7 @@ root_ns = Namespace('', description='Redfish V1')
 
 root_data={
     "@odata.id": "/redfish/v1/",
-    "@odata.type": "#ServiceRoot.v1_17_0.ServiceRoot",
+    "@odata.type": "#ServiceRoot.v1_18_0.ServiceRoot",
     "Id": "RootService",
     "Name": "Redfish Service",
     "RedfishVersion": "1.14.0",

--- a/redfish-server/sidecar-redfish/mylib/routers/updateService_router.py
+++ b/redfish-server/sidecar-redfish/mylib/routers/updateService_router.py
@@ -129,13 +129,12 @@ class FirmwareInventoryControlUnit_1(Resource):
             # "ReleaseDate": "2025-02-21T06:02:08Z", # TBD
             # 是否可更新
             "Updateable": False,    
-            "Version": load_raw_from_api(f"{CDU_BASE}/api/v1/cdu/components/display/version")["version"]["PLC"],
+            "Version": str(load_raw_from_api(f"{CDU_BASE}/api/v1/cdu/components/display/version")["version"]["PLC"]),
             "SoftwareId": "PLC-VERSION",
             "Oem": {}
         }
         return controlunit1_data
 
-# 要確認
 @update_ns.route("/UpdateService/SimpleUpdateActionInfo")
 class SimpleUpdateActionInfo(Resource):
     def get(self):
@@ -164,7 +163,7 @@ class ActionsUpdateCduSimpleUpdate(Resource):
     def post(self):
         
         ORIGIN_UPLOAD_API = f"{CDU_BASE}/api/v1/update_firmware"
-        file = request.files.get("File")
+        file = request.files.get("ImageFile")
         image_uri = request.form.get("ImageURI")  # 從表單中獲取 ImageURI
 
         # 如果同時有上傳檔案和 ImageURI，優先處理 ImageURI

--- a/redfish-server/sidecar-redfish/mylib/services/rf_log_service.py
+++ b/redfish-server/sidecar-redfish/mylib/services/rf_log_service.py
@@ -96,11 +96,11 @@ class RfLogService(BaseService):
             "Status": status.to_dict(),
             
             # Recommended field in interop validator
-            # "Actions": {
-            #     "#LogService.ClearLog": {
-            #         "target": f"/redfish/v1/Managers/CDU/LogServices/{log_id}/Actions/LogService.ClearLog",
-            #     }
-            # },
+            "Actions": {
+                "#LogService.ClearLog": {
+                    "target": f"/redfish/v1/Managers/CDU/LogServices/{log_service_id}/Actions/LogService.ClearLog",
+                }
+            },
             "Oem": {}
         }
 
@@ -143,7 +143,7 @@ class RfLogService(BaseService):
                 "@odata.id": f"/redfish/v1/Managers/CDU/LogServices/{log_service_id}/Entries/{sn}",
                 "Id": str(sn),
                 "Name": f"Log Entry {sn} of log_id:{log_service_id}",
-                "EntryType": RfLogEntryTypes.OEM,
+                "EntryType": RfLogEntryType.Oem,
             })
 
         return resp_json
@@ -158,7 +158,7 @@ class RfLogService(BaseService):
         
         log_entries = WebAppJsonReader.read_all_errorlog_entries()
 
-        if entry_id > str(len(log_entries)) or entry_id < "1":
+        if int(entry_id) > len(log_entries) or int(entry_id) < 1:
             raise ProjError(HTTPStatus.NOT_FOUND.value, f"/LogService/{log_service_id}/Entries/{entry_id} is not exist!")
 
         signal_record = log_entries[int(entry_id) - 1]

--- a/redfish-server/sidecar-redfish/mylib/utils/network_info.py
+++ b/redfish-server/sidecar-redfish/mylib/utils/network_info.py
@@ -26,8 +26,8 @@ def get_network_protocol_status():
     print(f"Listening ports: {listening_ports}")
     # 定義我們關心的協議及其預設埠號
     protocol_ports = {
-        "HTTP": 80,
-        "HTTPS": 5501,
+        "HTTP": None,
+        "HTTPS": 443,
         "SSH": 22,
         "SNMP": 9000,
         "NTP": 123,

--- a/redfish-server/sidecar-redfish/test/test_root_router.py
+++ b/redfish-server/sidecar-redfish/test/test_root_router.py
@@ -21,8 +21,7 @@ def test_redfish_v1_root(client):
     resp_json = response.json
     print(f"response.json: {resp_json}") # should use `pytest -s`, or run with `pytest -v --html=report.html`
     assert response.status_code == 200
-    assert resp_json["@odata.type"] == "#ServiceRoot.v1_17_0.ServiceRoot"
-    assert resp_json["@odata.type"] == "#ServiceRoot.v1_17_0.ServiceRoot"
+    assert resp_json["@odata.type"] == "#ServiceRoot.v1_18_0.ServiceRoot"
     assert resp_json["RedfishVersion"] == "1.14.0"
     assert resp_json["Id"] == "RootService"
 

--- a/redfish-server/sidecar-redfish/test/test_telemetry_service_router.py
+++ b/redfish-server/sidecar-redfish/test/test_telemetry_service_router.py
@@ -11,59 +11,130 @@ from http import HTTPStatus
 from mylib.models.rf_resource_model import RfResetType
 from mylib.models.rf_manager_model import RfResetToDefaultsType
 from mylib.utils.DateTimeUtil import DateTimeUtil
+from mylib.services.rf_telemetry_service import RfTelemetryService
 
-
+# telemetry_service_testcases = [
+#     {
+#         "endpoint": f'/redfish/v1/TelemetryService',
+#         "assert_cases": {
+#             "@odata.id": "/redfish/v1/TelemetryService",
+#             "@odata.type": "#TelemetryService.v1_3_4.TelemetryService",
+#             "@odata.context": "/redfish/v1/$metadata#TelemetryService.v1_3_4.TelemetryService",
+#             "Id": "TelemetryService",
+#         }
+#     },
+#     {
+#         "endpoint": f'/redfish/v1/TelemetryService/MetricReports',
+#         "assert_cases": {
+#             "@odata.id": "/redfish/v1/TelemetryService/MetricReports",
+#             "@odata.type": "#MetricReportCollection.MetricReportCollection",
+#             "Name": "CDU Metric Reports Collection",
+#             "Members@odata.count": 3,
+#             "Members": [
+#                 {
+#                 "@odata.id": "/redfish/v1/TelemetryService/MetricReports/CDU_Report_1"
+#                 },
+#                 {
+#                 "@odata.id": "/redfish/v1/TelemetryService/MetricReports/CDU_Report_2"
+#                 },
+#                 {
+#                 "@odata.id": "/redfish/v1/TelemetryService/MetricReports/CDU_Report_3"
+#                 }
+#             ]
+#         }
+#     },
+#     {
+#         "endpoint": "/redfish/v1/TelemetryService/MetricReports/<string:report_id>",
+#         "assert_cases": {
+#             "@odata.id": "/redfish/v1/TelemetryService/MetricReports/<string:report_id>",
+#             "Id": "<string:report_id>",
+#             "Timestamp": "2025-03-31T08:00:00Z",
+#             "MetricValues": [
+#                 {
+#                     "MetricId": "Coolant Supply Temperature (T1)",
+#                     "MetricValue": "62.5",
+#                     "Timestamp": "2025-06-10T00:15:15+00:00"
+#                 },
+#                 {
+#                     "MetricId": "Coolant Supply Temperature Spare (T1sp)",
+#                     "MetricValue": "21.0",
+#                     "Timestamp": "2025-06-10T00:15:15+00:00"
+#                 },
+#                 {
+#                     "MetricId": "Coolant Return Temperature (T2)",
+#                     "MetricValue": "423.0",
+#                     "Timestamp": "2025-06-10T00:15:15+00:00"
+#                 }
+#             ]
+#         }
+#     },
+# ]
 
 telemetry_service_testcases = [
     {
-        "endpoint": f'/redfish/v1/TelemetryService',
+        "endpoint": '/redfish/v1/TelemetryService',
         "assert_cases": {
             "@odata.id": "/redfish/v1/TelemetryService",
             "@odata.type": "#TelemetryService.v1_3_4.TelemetryService",
             "@odata.context": "/redfish/v1/$metadata#TelemetryService.v1_3_4.TelemetryService",
             "Id": "TelemetryService",
+            "Name": "CDU Telemetry Service",
         }
     },
     {
         "endpoint": f'/redfish/v1/TelemetryService/MetricReports',
         "assert_cases": {
             "@odata.id": "/redfish/v1/TelemetryService/MetricReports",
-            # "Members@odata.count": -1,
+            "@odata.type": "#MetricReportCollection.MetricReportCollection",
+            "Name": "CDU Metric Reports Collection",
             "Members": [
+                {"@odata.id": "/redfish/v1/TelemetryService/MetricReports/CDU_Report_1"},
+                {"@odata.id": "/redfish/v1/TelemetryService/MetricReports/CDU_Report_2"},
+                {"@odata.id": "/redfish/v1/TelemetryService/MetricReports/CDU_Report_3"}
+            ],
+            "Members@odata.count": 3, 
+        }
+    },
+    {
+        "endpoint": '/redfish/v1/TelemetryService/MetricReports/CDU_Report_1',
+        "assert_cases": {
+            "Id": "CDU_Report_1",
+            "@odata.id": "/redfish/v1/TelemetryService/MetricReports/CDU_Report_1",
+            "MetricValues": [
                 {
-                "@odata.id": "/redfish/v1/TelemetryService/MetricReports/1"
-                },
-                {
-                "@odata.id": "/redfish/v1/TelemetryService/MetricReports/2"
-                },
-                {
-                "@odata.id": "/redfish/v1/TelemetryService/MetricReports/3"
+                    "MetricId",
+                    "MetricValue",
+                    "Timestamp"
                 }
             ]
         }
     },
     {
-        "endpoint": f'/redfish/v1/TelemetryService/MetricReports/1',
+        "endpoint" : f'/redfish/v1/TelemetryService/MetricDefinitions',
         "assert_cases": {
-            "@odata.id": "/redfish/v1/TelemetryService/MetricReports/1",
-            "Id": "CDU_Report_001",
-            "Timestamp": os.getenv("DATETIME_FORMAT"),
-            "MetricValues": [
-                {
-                    "MetricId": "temp_clntSply",
-                    "MetricValue": 0,
-                    "Timestamp": "2025-03-31T08:00:00Z"
-                },
-                {
-                    "MetricId": "temp_clntSplySpare",
-                    "MetricValue": 0,
-                    "Timestamp": "2025-03-31T08:00:00Z"
-                },
-            ]
+            "@odata.id": "/redfish/v1/TelemetryService/MetricDefinitions",
+            "@odata.type": "#MetricDefinitionCollection.MetricDefinitionCollection",
+            "@odata.context": "/redfish/v1/$metadata#MetricDefinitionCollection.MetricDefinitionCollection",
+            "Name": "Metric Definition Collection",
+            "Members":[
+                {"@odata.id": "/redfish/v1/TelemetryService/MetricDefinitions/time"},
+                {"@odata.id": "/redfish/v1/TelemetryService/MetricDefinitions/coolant_supply_temperature"}
+            ],
+            "Members@odata.count": 2,
         }
     },
+    {
+        "endpoint" : f'/redfish/v1/TelemetryService/MetricDefinitions/time',
+        "assert_cases" : {
+            "@odata.id" : "/redfish/v1/TelemetryService/MetricDefinitions/time",
+            "@odata.type" : "#MetricDefinition.v1_0_0.MetricDefinition",
+            "@odata.context" : "/redfish/v1/$metadata#MetricDefinition.MetricDefinition",
+            "Id" : "time",
+            "Name" : "time",
+            "MetricDataType": "DateTime",
+        }
+    }
 ]
-
 
 
 
@@ -85,36 +156,64 @@ telemetry_service_testcases = [
 # N::::::N        N::::::N oo:::::::::::oo  r:::::r            m::::m   m::::m   m::::m a::::::::::aa:::al::::::l
 # NNNNNNNN         NNNNNNN   ooooooooooo    rrrrrrr            mmmmmm   mmmmmm   mmmmmm  aaaaaaaaaa  aaaallllllll
 ##
-@pytest.mark.parametrize("testcase", telemetry_service_testcases)
-def test_telemetry_service_normal_api(client, basic_auth_header, testcase):
-    """[TestCase] TelemetryService API"""
-    # 獲取當前測試案例的序號
-    index = telemetry_service_testcases.index(testcase) + 1
-    print(f"Running test case {index}/{len(telemetry_service_testcases)}: {testcase}")
+# @pytest.mark.parametrize("testcase", telemetry_service_testcases)
+# def test_telemetry_service_normal_api(client, basic_auth_header, testcase):
+#     """[TestCase] TelemetryService API"""
+#     # 獲取當前測試案例的序號
+#     index = telemetry_service_testcases.index(testcase) + 1
+#     print(f"Running test case {index}/{len(telemetry_service_testcases)}: {testcase}")
 
-    print(f"Endpoint: {testcase['endpoint']}")
-    response = client.get(testcase['endpoint'], headers=basic_auth_header)
-    resp_json = response.json
-    print(f"Response: {resp_json}")
-    assert response.status_code == 200
+#     print(f"Endpoint: {testcase['endpoint']}")
+#     response = client.get(testcase['endpoint'], headers=basic_auth_header)
+#     resp_json = response.json
+#     print(f"Response: {resp_json}")
+#     assert response.status_code == 200
     
-    print(f"Response json: {json.dumps(resp_json, indent=2, ensure_ascii=False)}")
-    for key, value in testcase['assert_cases'].items():
-        try:
-            if key == "MetricValues":
-                assert len(resp_json[key]) > 3
-            elif key == "Members":
-                assert len(resp_json[key]) == resp_json["Members@odata.count"]
-            elif key == "Timestamp":
-                assert DateTimeUtil.is_match_format(resp_json[key], os.getenv("DATETIME_FORMAT"))
-            elif key == "Status":
-                assert isinstance(resp_json["Status"], dict)
-                # assert resp_json["Status"]["State"] in ["Absent", "Enabled", "Disabled"]
-                assert resp_json["Status"]["Health"] in ["OK", "Warning", "Critical"]
-            else:
-                assert resp_json[key] == value
+#     print(f"Response json: {json.dumps(resp_json, indent=2, ensure_ascii=False)}")
+#     for key, value in testcase['assert_cases'].items():
+#         try:
+#             if key == "MetricValues":
+#                 assert len(resp_json[key]) > 3
+#             elif key == "Members":
+#                 assert len(resp_json[key]) == resp_json["Members@odata.count"]
+#             elif key == "Timestamp":
+#                 assert DateTimeUtil.is_match_format(resp_json[key], os.getenv("DATETIME_FORMAT"))
+#             elif key == "Status":
+#                 assert isinstance(resp_json["Status"], dict)
+#                 # assert resp_json["Status"]["State"] in ["Absent", "Enabled", "Disabled"]
+#                 assert resp_json["Status"]["Health"] in ["OK", "Warning", "Critical"]
+#             else:
+#                 assert resp_json[key] == value
             
-            print(f"PASS: `{key}` of response json is expected to be {value}")
-        except AssertionError as e:
-            print(f"AssertionError: {e}, key: {key}, value: {value}")
-            raise e
+#             print(f"PASS: `{key}` of response json is expected to be {value}")
+#         except AssertionError as e:
+#             print(f"AssertionError: {e}, key: {key}, value: {value}")
+#             raise e
+
+@pytest.mark.parametrize("testcase", telemetry_service_testcases)
+def test_telemetry_service_api(client, basic_auth_header, testcase):
+    """測試 TelemetryService 相關 API 是否正確回應預期的欄位與值"""
+    response = client.get(testcase["endpoint"], headers=basic_auth_header)
+    resp_json = response.json
+
+    assert response.status_code == 200, f"Unexpected status code: {response.status_code}"
+
+    for key, value in testcase["assert_cases"].items():
+
+        if key == "Members@odata.count" :
+            actual_count = resp_json.get("Members@odata.count", 0)
+            assert 0 < actual_count <= 2048, f"Members@odata.count out of range: {actual_count}"
+
+        elif key == "Members":
+            assert isinstance(resp_json["Members"], list), "Members 應為 list"
+            count = len(resp_json["Members"])
+            assert 0 < count <= 2048 , f"Members count out of range: {count}"
+
+        elif key == "MetricValues":
+            assert isinstance(resp_json["MetricValues"], list), "MetricValues 應為 list"
+            for item in resp_json["MetricValues"]:
+                for field in ["MetricId", "MetricValue", "Timestamp"]:
+                    assert field in item, f"MetricValues 缺少欄位：{field}，內容：{item}"
+
+        else:
+            assert resp_json[key] == value


### PR DESCRIPTION
0620
1.RestAPI修正components/Oem取出fan值不為0
2.更新PrimaryCoolantConnectors/1 ControlMode值改為Automatic
3.updateservice的file改為ImageFile
4.新增rf_ethernetinterfaces_model.py
5.修正ssh取值錯誤
6.修正PrimaryCoolantConnectors/1 Manual/Automatic
7.PLC version修正, SimpleUpdateActionInfo修正, UpdateService.SimpleUpdate:File->ImageFile
8.pump swap time 修正
9.networkprotocol新增ProtocolEnabled存入SQLite
10.修改/redfish的內容
11.metadata.xml新增資源
12.新增action Pump.SetMode
13.update test case for ServiceRoot
14.修正 RfMetricReportDefinitionModel 中的 SuppressRepeatedMetricValues 屬性名稱為 SuppressRepeatedMetricValue
15.擴展 RfMetricReportDefinitionModel 和 RfMetricReportModel，新增計算算法、時間範圍、鏈接及報告屬性，以支持更全面的報告定義和度量功能
16.擴展 RfMetricReportDefinitionModel 和 RfMetricReportDefinitionCollectionModel 的屬性，並實作fetch_TelemetryService_MetricReportDefinitions 方法以支持報告定義的獲取